### PR TITLE
實現完整的3頁網站根據PRD需求

### DIFF
--- a/app/corporate/page.tsx
+++ b/app/corporate/page.tsx
@@ -1,0 +1,341 @@
+import { Metadata } from 'next'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+
+export const metadata: Metadata = {
+  title: '現代企業官網 | 專業企業解決方案',
+  description: '領先的企業解決方案提供商，為您的業務增長提供專業服務和創新技術支持。',
+  keywords: ['企業解決方案', '商業服務', '專業諮詢', '企業管理'],
+  openGraph: {
+    title: '現代企業官網 | 專業企業解決方案',
+    description: '領先的企業解決方案提供商',
+    type: 'website',
+    locale: 'zh_TW',
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
+
+export default function CorporatePage() {
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Section 1: 透明導航 */}
+      <nav className="bg-white/90 backdrop-blur-md border-b border-blue-100 sticky top-0 z-50">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="text-2xl font-bold text-blue-900">Corporate Solutions</div>
+            <div className="hidden md:flex space-x-8">
+              <Link href="/corporate" className="text-blue-600 font-medium border-b-2 border-blue-500">
+                企業官網
+              </Link>
+              <Link href="/tech-store" className="text-gray-600 hover:text-blue-600 transition-colors">
+                科技商店
+              </Link>
+              <Link href="/portfolio" className="text-gray-600 hover:text-blue-600 transition-colors">
+                作品集
+              </Link>
+            </div>
+            <div className="md:hidden">
+              <Button size="sm" className="bg-blue-600 hover:bg-blue-700">
+                選單
+              </Button>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      {/* Section 2: 漸層主視覺 */}
+      <section className="bg-gradient-to-br from-blue-50 via-white to-blue-100 py-24 relative overflow-hidden">
+        <div className="absolute inset-0">
+          <div className="absolute top-20 left-10 w-72 h-72 bg-blue-200/30 rounded-full blur-3xl"></div>
+          <div className="absolute bottom-20 right-10 w-96 h-96 bg-blue-300/20 rounded-full blur-3xl"></div>
+        </div>
+        
+        <div className="container mx-auto px-6 relative">
+          <div className="max-w-6xl mx-auto">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+              <div className="space-y-8">
+                <Badge variant="secondary" className="bg-blue-100 text-blue-700 border-blue-200">
+                  🚀 專業企業服務
+                </Badge>
+                
+                <h1 className="text-6xl md:text-7xl font-bold leading-tight">
+                  <span className="text-blue-900 block">專業</span>
+                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-blue-800">
+                    企業解決方案
+                  </span>
+                </h1>
+                
+                <p className="text-xl text-gray-600 leading-relaxed max-w-xl">
+                  我們為企業提供全面的數位轉型與商業諮詢服務，幫助您在競爭激烈的市場中脫穎而出，實現業務增長目標。
+                </p>
+                
+                <div className="flex flex-col sm:flex-row gap-4">
+                  <Button size="lg" className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700">
+                    立即諮詢
+                  </Button>
+                  <Button variant="outline" size="lg" className="border-blue-500 text-blue-600 hover:bg-blue-50">
+                    了解更多
+                  </Button>
+                </div>
+              </div>
+              
+              <div className="relative">
+                <Card className="transform rotate-3 hover:rotate-0 transition-transform duration-500 shadow-2xl">
+                  <CardHeader>
+                    <div className="h-32 bg-gradient-to-br from-blue-400 to-blue-600 rounded-lg mb-4"></div>
+                    <CardTitle className="text-blue-900 text-xl">企業數位化解決方案</CardTitle>
+                    <CardDescription>為您的企業量身打造的專業服務</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-3">
+                      <div className="h-3 bg-gray-200 rounded-full w-3/4"></div>
+                      <div className="h-3 bg-gray-200 rounded-full w-1/2"></div>
+                      <div className="flex space-x-2 pt-2">
+                        <div className="w-8 h-8 bg-blue-300 rounded-full"></div>
+                        <div className="w-8 h-8 bg-blue-400 rounded-full"></div>
+                        <div className="w-8 h-8 bg-blue-200 rounded-full"></div>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 3: 成就數據 */}
+      <section className="py-24 bg-white">
+        <div className="container mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl font-bold text-blue-900 mb-6">我們的成就</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              多年來，我們已經為數百家企業提供專業服務，創造了卓越的商業價值
+            </p>
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+            <Card className="text-center p-6 border-blue-100 hover:shadow-lg transition-shadow">
+              <CardContent className="pt-6">
+                <div className="text-4xl font-bold text-blue-600 mb-2">500+</div>
+                <div className="text-gray-600 font-medium">成功專案</div>
+              </CardContent>
+            </Card>
+            
+            <Card className="text-center p-6 border-blue-100 hover:shadow-lg transition-shadow">
+              <CardContent className="pt-6">
+                <div className="text-4xl font-bold text-blue-600 mb-2">98%</div>
+                <div className="text-gray-600 font-medium">客戶滿意度</div>
+              </CardContent>
+            </Card>
+            
+            <Card className="text-center p-6 border-blue-100 hover:shadow-lg transition-shadow">
+              <CardContent className="pt-6">
+                <div className="text-4xl font-bold text-blue-600 mb-2">10+</div>
+                <div className="text-gray-600 font-medium">服務年資</div>
+              </CardContent>
+            </Card>
+            
+            <Card className="text-center p-6 border-blue-100 hover:shadow-lg transition-shadow">
+              <CardContent className="pt-6">
+                <div className="text-4xl font-bold text-blue-600 mb-2">24/7</div>
+                <div className="text-gray-600 font-medium">專業支援</div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 4: 核心優勢 */}
+      <section className="py-24 bg-blue-50">
+        <div className="container mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl font-bold text-blue-900 mb-6">核心優勢</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              我們的專業團隊提供全方位的企業解決方案，確保您的業務保持競爭優勢
+            </p>
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <Card className="hover:shadow-xl transition-shadow duration-300">
+              <CardHeader>
+                <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
+                  <div className="w-6 h-6 bg-blue-600 rounded"></div>
+                </div>
+                <CardTitle className="text-blue-900">數位轉型</CardTitle>
+                <CardDescription>協助企業進行全面的數位化升級</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600">
+                  從傳統業務模式轉向數位化營運，提升效率並擴大市場覆蓋範圍。
+                </p>
+              </CardContent>
+            </Card>
+            
+            <Card className="hover:shadow-xl transition-shadow duration-300">
+              <CardHeader>
+                <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
+                  <div className="w-6 h-6 bg-blue-600 rounded-full"></div>
+                </div>
+                <CardTitle className="text-blue-900">商業諮詢</CardTitle>
+                <CardDescription>提供專業的策略規劃與商業建議</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600">
+                  深度分析市場趨勢，制定適合的商業策略，確保企業持續成長。
+                </p>
+              </CardContent>
+            </Card>
+            
+            <Card className="hover:shadow-xl transition-shadow duration-300">
+              <CardHeader>
+                <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
+                  <div className="w-6 h-6 bg-blue-600 rounded-lg transform rotate-45"></div>
+                </div>
+                <CardTitle className="text-blue-900">技術支援</CardTitle>
+                <CardDescription>24/7 全天候技術支援服務</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600">
+                  專業技術團隊隨時待命，確保您的系統穩定運行，業務不中斷。
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 5: 客戶見證 */}
+      <section className="py-24 bg-white">
+        <div className="container mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl font-bold text-blue-900 mb-6">客戶見證</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              聽聽我們的客戶如何評價我們的專業服務
+            </p>
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <Card className="border-blue-100">
+              <CardContent className="p-6">
+                <div className="flex items-center mb-4">
+                  <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mr-4">
+                    <span className="text-blue-600 font-bold">王</span>
+                  </div>
+                  <div>
+                    <div className="font-semibold text-blue-900">王總經理</div>
+                    <div className="text-sm text-gray-600">科技公司</div>
+                  </div>
+                </div>
+                <p className="text-gray-600 leading-relaxed">
+                  &ldquo;專業的服務團隊和高效的解決方案，幫助我們公司成功完成數位轉型，業績提升了30%。&rdquo;
+                </p>
+              </CardContent>
+            </Card>
+            
+            <Card className="border-blue-100">
+              <CardContent className="p-6">
+                <div className="flex items-center mb-4">
+                  <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mr-4">
+                    <span className="text-blue-600 font-bold">李</span>
+                  </div>
+                  <div>
+                    <div className="font-semibold text-blue-900">李執行長</div>
+                    <div className="text-sm text-gray-600">製造業</div>
+                  </div>
+                </div>
+                <p className="text-gray-600 leading-relaxed">
+                  &ldquo;從諮詢到實施，整個過程都非常順利。他們的專業建議為我們節省了大量成本。&rdquo;
+                </p>
+              </CardContent>
+            </Card>
+            
+            <Card className="border-blue-100">
+              <CardContent className="p-6">
+                <div className="flex items-center mb-4">
+                  <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mr-4">
+                    <span className="text-blue-600 font-bold">陳</span>
+                  </div>
+                  <div>
+                    <div className="font-semibold text-blue-900">陳董事長</div>
+                    <div className="text-sm text-gray-600">零售集團</div>
+                  </div>
+                </div>
+                <p className="text-gray-600 leading-relaxed">
+                  &ldquo;優秀的團隊合作精神和創新思維，讓我們在激烈的市場競爭中脫穎而出。&rdquo;
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 6: 行動呼籲 */}
+      <section className="py-24 bg-gradient-to-r from-blue-600 to-blue-800">
+        <div className="container mx-auto px-6 text-center">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-4xl md:text-5xl font-bold text-white mb-6">
+              準備開始您的數位轉型之旅嗎？
+            </h2>
+            <p className="text-xl text-blue-100 mb-8 leading-relaxed">
+              立即聯繫我們的專業團隊，獲得免費的商業諮詢服務，讓我們幫助您實現業務目標。
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Button size="lg" className="bg-white text-blue-600 hover:bg-gray-100">
+                免費諮詢
+              </Button>
+              <Button variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-blue-600">
+                下載資料
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 7: 現代頁尾 */}
+      <footer className="bg-blue-50 border-t border-blue-100 py-16">
+        <div className="container mx-auto px-6">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
+            <div className="col-span-1 md:col-span-2">
+              <div className="text-2xl font-bold text-blue-900 mb-4">Corporate Solutions</div>
+              <p className="text-gray-600 leading-relaxed max-w-md">
+                專業的企業解決方案提供商，致力於為客戶創造最大的商業價值。
+              </p>
+            </div>
+            
+            <div>
+              <h3 className="font-semibold text-blue-900 mb-4">服務項目</h3>
+              <ul className="space-y-2 text-gray-600">
+                <li>數位轉型</li>
+                <li>商業諮詢</li>
+                <li>技術支援</li>
+                <li>策略規劃</li>
+              </ul>
+            </div>
+            
+            <div>
+              <h3 className="font-semibold text-blue-900 mb-4">快速連結</h3>
+              <ul className="space-y-2 text-gray-600">
+                <li><Link href="/corporate" className="hover:text-blue-600 transition-colors">企業官網</Link></li>
+                <li><Link href="/tech-store" className="hover:text-blue-600 transition-colors">科技商店</Link></li>
+                <li><Link href="/portfolio" className="hover:text-blue-600 transition-colors">作品集</Link></li>
+              </ul>
+            </div>
+          </div>
+          
+          <Separator className="my-8" />
+          
+          <div className="text-center text-gray-600">
+            <p>&copy; 2025 Corporate Solutions. 版權所有。</p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,0 +1,406 @@
+import { Metadata } from 'next'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+
+export const metadata: Metadata = {
+  title: '設計師作品集 | 創意設計作品展示',
+  description: '瀏覽我們的設計作品集，包含品牌設計、網頁設計、UI/UX設計等創意作品展示。',
+  keywords: ['設計作品集', '創意設計', '品牌設計', '網頁設計', 'UI/UX設計', '平面設計'],
+  openGraph: {
+    title: '設計師作品集 | 創意設計作品展示',
+    description: '瀏覽我們的創意設計作品集',
+    type: 'website',
+    locale: 'zh_TW',
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
+
+export default function PortfolioPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Section 1: 創意導航 */}
+      <nav className="bg-gradient-to-r from-purple-50 to-pink-50 border-b border-purple-100 sticky top-0 z-50 backdrop-blur-md">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
+              Creative Portfolio
+            </div>
+            <div className="hidden md:flex space-x-8">
+              <Link href="/corporate" className="text-gray-600 hover:text-purple-600 transition-colors">
+                企業官網
+              </Link>
+              <Link href="/tech-store" className="text-gray-600 hover:text-purple-600 transition-colors">
+                科技商店
+              </Link>
+              <Link href="/portfolio" className="text-purple-600 font-medium border-b-2 border-purple-500">
+                作品集
+              </Link>
+            </div>
+            <div className="md:hidden">
+              <Button size="sm" className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600">
+                選單
+              </Button>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      {/* Section 2: 設計師介紹 */}
+      <section className="bg-gradient-to-br from-purple-50 via-pink-50 to-orange-50 py-24 relative overflow-hidden">
+        <div className="absolute inset-0">
+          <div className="absolute top-20 left-10 w-72 h-72 bg-purple-200/30 rounded-full blur-3xl"></div>
+          <div className="absolute bottom-20 right-10 w-96 h-96 bg-pink-200/20 rounded-full blur-3xl"></div>
+          <div className="absolute top-1/2 left-1/3 w-64 h-64 bg-orange-200/20 rounded-full blur-3xl"></div>
+        </div>
+        
+        <div className="container mx-auto px-6 relative">
+          <div className="max-w-6xl mx-auto">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+              <div className="space-y-8">
+                <Badge className="bg-gradient-to-r from-purple-100 to-pink-100 text-purple-700 border-purple-200">
+                  ✨ 創意設計師
+                </Badge>
+                
+                <h1 className="text-6xl md:text-7xl font-bold leading-tight">
+                  <span className="text-gray-900 block">設計</span>
+                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-orange-500">
+                    改變世界
+                  </span>
+                </h1>
+                
+                <p className="text-xl text-gray-600 leading-relaxed max-w-xl">
+                  我是一位充滿熱情的設計師，致力於創造美麗且有意義的視覺體驗。每個作品都是創意與技術的完美結合。
+                </p>
+                
+                <div className="flex flex-col sm:flex-row gap-4">
+                  <Button size="lg" className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600">
+                    查看作品
+                  </Button>
+                  <Button variant="outline" size="lg" className="border-purple-500 text-purple-600 hover:bg-purple-50">
+                    聯絡合作
+                  </Button>
+                </div>
+                
+                <div className="flex items-center space-x-6 pt-4">
+                  <div className="text-center">
+                    <div className="text-2xl font-bold text-purple-600">5+</div>
+                    <div className="text-sm text-gray-600">年經驗</div>
+                  </div>
+                  <Separator orientation="vertical" className="h-12" />
+                  <div className="text-center">
+                    <div className="text-2xl font-bold text-pink-600">100+</div>
+                    <div className="text-sm text-gray-600">完成專案</div>
+                  </div>
+                  <Separator orientation="vertical" className="h-12" />
+                  <div className="text-center">
+                    <div className="text-2xl font-bold text-orange-600">50+</div>
+                    <div className="text-sm text-gray-600">滿意客戶</div>
+                  </div>
+                </div>
+              </div>
+              
+              <div className="relative">
+                <div className="relative z-10">
+                  {/* Designer Profile Card */}
+                  <Card className="shadow-2xl border-purple-100 overflow-hidden">
+                    <div className="h-48 bg-gradient-to-br from-purple-400 via-pink-500 to-orange-400 relative">
+                      <div className="absolute inset-0 bg-black/20"></div>
+                      <div className="absolute bottom-6 left-6">
+                        <div className="w-20 h-20 bg-white rounded-full flex items-center justify-center shadow-lg">
+                          <span className="text-2xl font-bold text-purple-600">AC</span>
+                        </div>
+                      </div>
+                    </div>
+                    <CardHeader>
+                      <CardTitle className="text-gray-900 text-xl">Alex Chen</CardTitle>
+                      <CardDescription>創意設計師 & 視覺藝術家</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-4">
+                        <p className="text-gray-600 text-sm">
+                          專精於品牌識別、網頁設計與用戶體驗設計
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          <Badge variant="outline" className="text-purple-600 border-purple-200">UI/UX</Badge>
+                          <Badge variant="outline" className="text-pink-600 border-pink-200">品牌設計</Badge>
+                          <Badge variant="outline" className="text-orange-600 border-orange-200">插畫</Badge>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 3: 設計服務 */}
+      <section className="py-24 bg-white">
+        <div className="container mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl font-bold text-gray-900 mb-6">設計服務</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              提供全方位的設計服務，從品牌識別到數位體驗，為您的品牌創造獨特的視覺語言
+            </p>
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <Card className="group hover:shadow-xl transition-all duration-300 border-purple-100">
+              <CardHeader>
+                <div className="w-16 h-16 bg-gradient-to-br from-purple-500 to-purple-600 rounded-2xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                  <div className="w-8 h-8 bg-white rounded-lg"></div>
+                </div>
+                <CardTitle className="text-gray-900">品牌識別設計</CardTitle>
+                <CardDescription>打造獨特的品牌形象</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600 mb-4">
+                  從 Logo 設計到完整的品牌識別系統，為您的品牌建立一致且有力的視覺形象。
+                </p>
+                <ul className="text-sm text-gray-500 space-y-1">
+                  <li>• Logo 設計與標準字</li>
+                  <li>• 品牌色彩與字體規範</li>
+                  <li>• 名片與文具設計</li>
+                </ul>
+              </CardContent>
+            </Card>
+            
+            <Card className="group hover:shadow-xl transition-all duration-300 border-pink-100">
+              <CardHeader>
+                <div className="w-16 h-16 bg-gradient-to-br from-pink-500 to-pink-600 rounded-2xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                  <div className="w-8 h-8 bg-white rounded-full"></div>
+                </div>
+                <CardTitle className="text-gray-900">網頁與UI設計</CardTitle>
+                <CardDescription>現代化的數位體驗設計</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600 mb-4">
+                  設計美觀且實用的網站介面，提供優秀的使用者體驗和視覺效果。
+                </p>
+                <ul className="text-sm text-gray-500 space-y-1">
+                  <li>• 響應式網頁設計</li>
+                  <li>• 使用者介面設計</li>
+                  <li>• 互動原型製作</li>
+                </ul>
+              </CardContent>
+            </Card>
+            
+            <Card className="group hover:shadow-xl transition-all duration-300 border-orange-100">
+              <CardHeader>
+                <div className="w-16 h-16 bg-gradient-to-br from-orange-500 to-orange-600 rounded-2xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                  <div className="w-8 h-8 bg-white rounded-lg transform rotate-45"></div>
+                </div>
+                <CardTitle className="text-gray-900">插畫與視覺設計</CardTitle>
+                <CardDescription>原創插畫與視覺創作</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600 mb-4">
+                  創作獨特的插畫作品和視覺元素，為您的品牌增添創意與個性。
+                </p>
+                <ul className="text-sm text-gray-500 space-y-1">
+                  <li>• 手繪插畫創作</li>
+                  <li>• 圖標與符號設計</li>
+                  <li>• 海報與宣傳設計</li>
+                </ul>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 4: 設計作品 */}
+      <section className="py-24 bg-gradient-to-b from-gray-50 to-white">
+        <div className="container mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl font-bold text-gray-900 mb-6">精選作品</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              每一個作品都承載著獨特的創意理念，展現設計的力量與美感
+            </p>
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {/* Project 1 */}
+            <Card className="group overflow-hidden border-0 shadow-lg hover:shadow-2xl transition-all duration-500">
+              <div className="aspect-square bg-gradient-to-br from-purple-400 via-purple-500 to-purple-600 relative overflow-hidden">
+                <div className="absolute inset-0 bg-black/20 group-hover:bg-black/40 transition-all duration-300"></div>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="text-white text-4xl font-bold opacity-30 group-hover:opacity-50 transition-opacity">
+                    BRAND
+                  </div>
+                </div>
+                <div className="absolute top-4 right-4">
+                  <Badge className="bg-white/20 text-white border-white/30">品牌設計</Badge>
+                </div>
+                <div className="absolute bottom-6 left-6 right-6 transform translate-y-4 group-hover:translate-y-0 transition-transform duration-300">
+                  <h3 className="text-white text-xl font-bold mb-2">企業品牌識別</h3>
+                  <p className="text-purple-100 text-sm opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    為新創科技公司打造的現代化品牌形象系統
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            {/* Project 2 */}
+            <Card className="group overflow-hidden border-0 shadow-lg hover:shadow-2xl transition-all duration-500">
+              <div className="aspect-square bg-gradient-to-br from-pink-400 via-pink-500 to-pink-600 relative overflow-hidden">
+                <div className="absolute inset-0 bg-black/20 group-hover:bg-black/40 transition-all duration-300"></div>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="text-white text-4xl font-bold opacity-30 group-hover:opacity-50 transition-opacity">
+                    WEB
+                  </div>
+                </div>
+                <div className="absolute top-4 right-4">
+                  <Badge className="bg-white/20 text-white border-white/30">網頁設計</Badge>
+                </div>
+                <div className="absolute bottom-6 left-6 right-6 transform translate-y-4 group-hover:translate-y-0 transition-transform duration-300">
+                  <h3 className="text-white text-xl font-bold mb-2">電商平台設計</h3>
+                  <p className="text-pink-100 text-sm opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    響應式電商網站設計，提供優質的購物體驗
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            {/* Project 3 */}
+            <Card className="group overflow-hidden border-0 shadow-lg hover:shadow-2xl transition-all duration-500">
+              <div className="aspect-square bg-gradient-to-br from-orange-400 via-orange-500 to-orange-600 relative overflow-hidden">
+                <div className="absolute inset-0 bg-black/20 group-hover:bg-black/40 transition-all duration-300"></div>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="text-white text-4xl font-bold opacity-30 group-hover:opacity-50 transition-opacity">
+                    APP
+                  </div>
+                </div>
+                <div className="absolute top-4 right-4">
+                  <Badge className="bg-white/20 text-white border-white/30">UI/UX</Badge>
+                </div>
+                <div className="absolute bottom-6 left-6 right-6 transform translate-y-4 group-hover:translate-y-0 transition-transform duration-300">
+                  <h3 className="text-white text-xl font-bold mb-2">行動應用介面</h3>
+                  <p className="text-orange-100 text-sm opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    以使用者為中心的移動應用程式界面設計
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            {/* Project 4 */}
+            <Card className="group overflow-hidden border-0 shadow-lg hover:shadow-2xl transition-all duration-500">
+              <div className="aspect-square bg-gradient-to-br from-blue-400 via-blue-500 to-blue-600 relative overflow-hidden">
+                <div className="absolute inset-0 bg-black/20 group-hover:bg-black/40 transition-all duration-300"></div>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="text-white text-4xl font-bold opacity-30 group-hover:opacity-50 transition-opacity">
+                    PRINT
+                  </div>
+                </div>
+                <div className="absolute top-4 right-4">
+                  <Badge className="bg-white/20 text-white border-white/30">平面設計</Badge>
+                </div>
+                <div className="absolute bottom-6 left-6 right-6 transform translate-y-4 group-hover:translate-y-0 transition-transform duration-300">
+                  <h3 className="text-white text-xl font-bold mb-2">宣傳物料設計</h3>
+                  <p className="text-blue-100 text-sm opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    企業宣傳冊、海報等印刷物設計
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            {/* Project 5 */}
+            <Card className="group overflow-hidden border-0 shadow-lg hover:shadow-2xl transition-all duration-500">
+              <div className="aspect-square bg-gradient-to-br from-green-400 via-green-500 to-green-600 relative overflow-hidden">
+                <div className="absolute inset-0 bg-black/20 group-hover:bg-black/40 transition-all duration-300"></div>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="text-white text-4xl font-bold opacity-30 group-hover:opacity-50 transition-opacity">
+                    ICON
+                  </div>
+                </div>
+                <div className="absolute top-4 right-4">
+                  <Badge className="bg-white/20 text-white border-white/30">圖標設計</Badge>
+                </div>
+                <div className="absolute bottom-6 left-6 right-6 transform translate-y-4 group-hover:translate-y-0 transition-transform duration-300">
+                  <h3 className="text-white text-xl font-bold mb-2">圖標系統設計</h3>
+                  <p className="text-green-100 text-sm opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    一致性的圖標設計系統，提升產品視覺效果
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            {/* Project 6 */}
+            <Card className="group overflow-hidden border-0 shadow-lg hover:shadow-2xl transition-all duration-500">
+              <div className="aspect-square bg-gradient-to-br from-indigo-400 via-indigo-500 to-indigo-600 relative overflow-hidden">
+                <div className="absolute inset-0 bg-black/20 group-hover:bg-black/40 transition-all duration-300"></div>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="text-white text-4xl font-bold opacity-30 group-hover:opacity-50 transition-opacity">
+                    ART
+                  </div>
+                </div>
+                <div className="absolute top-4 right-4">
+                  <Badge className="bg-white/20 text-white border-white/30">插畫</Badge>
+                </div>
+                <div className="absolute bottom-6 left-6 right-6 transform translate-y-4 group-hover:translate-y-0 transition-transform duration-300">
+                  <h3 className="text-white text-xl font-bold mb-2">原創插畫創作</h3>
+                  <p className="text-indigo-100 text-sm opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    手繪插畫與數位藝術創作，展現獨特風格
+                  </p>
+                </div>
+              </div>
+            </Card>
+          </div>
+          
+          <div className="text-center mt-16">
+            <Button size="lg" className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600">
+              查看完整作品集
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="bg-gray-900 text-white py-16">
+        <div className="container mx-auto px-6">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
+            <div className="col-span-1 md:col-span-2">
+              <div className="text-2xl font-bold bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent mb-4">
+                Creative Portfolio
+              </div>
+              <p className="text-gray-300 leading-relaxed max-w-md">
+                用設計創造美好，讓每個作品都能傳達獨特的故事與情感。
+              </p>
+            </div>
+            
+            <div>
+              <h3 className="font-semibold text-white mb-4">設計服務</h3>
+              <ul className="space-y-2 text-gray-300">
+                <li>品牌識別設計</li>
+                <li>網頁與UI設計</li>
+                <li>插畫與視覺設計</li>
+                <li>平面設計</li>
+              </ul>
+            </div>
+            
+            <div>
+              <h3 className="font-semibold text-white mb-4">快速連結</h3>
+              <ul className="space-y-2 text-gray-300">
+                <li><Link href="/corporate" className="hover:text-purple-400 transition-colors">企業官網</Link></li>
+                <li><Link href="/tech-store" className="hover:text-purple-400 transition-colors">科技商店</Link></li>
+                <li><Link href="/portfolio" className="hover:text-purple-400 transition-colors">作品集</Link></li>
+              </ul>
+            </div>
+          </div>
+          
+          <Separator className="my-8 bg-gray-700" />
+          
+          <div className="text-center text-gray-400">
+            <p>&copy; 2025 Creative Portfolio. 版權所有。設計改變世界。</p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,11 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: 'https://yourdomain.com/sitemap.xml', // This should be updated during deployment
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://yourdomain.com' // This should be updated during deployment
+  
+  return [
+    {
+      url: `${baseUrl}/corporate`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/tech-store`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/portfolio`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/app/tech-store/page.tsx
+++ b/app/tech-store/page.tsx
@@ -1,0 +1,318 @@
+import { Metadata } from 'next'
+import Link from 'next/link'
+import Image from 'next/image'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+
+export const metadata: Metadata = {
+  title: '科技產品商店 | 最新科技產品選購',
+  description: '探索最新的科技產品，從智慧手機到筆記型電腦，為您提供高品質的科技商品選擇。',
+  keywords: ['科技產品', '電子商品', '智慧型手機', '筆記型電腦', '科技商店'],
+  openGraph: {
+    title: '科技產品商店 | 最新科技產品選購',
+    description: '探索最新的科技產品選擇',
+    type: 'website',
+    locale: 'zh_TW',
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
+
+interface Product {
+  id: number
+  name: string
+  price_in_cents: number
+  image_url: string
+}
+
+async function getProducts(): Promise<Product[]> {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/products`, {
+      cache: 'no-store'
+    })
+    if (!res.ok) {
+      throw new Error('Failed to fetch products')
+    }
+    return res.json()
+  } catch (error) {
+    console.error('Error fetching products:', error)
+    return []
+  }
+}
+
+function formatPrice(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`
+}
+
+export default async function TechStorePage() {
+  const products = await getProducts()
+
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Section 1: 科技導航 */}
+      <nav className="bg-slate-900/95 backdrop-blur-md border-b border-blue-800 sticky top-0 z-50">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="text-2xl font-bold text-blue-400">TechStore</div>
+            <div className="hidden md:flex space-x-8">
+              <Link href="/corporate" className="text-gray-300 hover:text-blue-400 transition-colors">
+                企業官網
+              </Link>
+              <Link href="/tech-store" className="text-blue-400 font-medium border-b-2 border-blue-400">
+                科技商店
+              </Link>
+              <Link href="/portfolio" className="text-gray-300 hover:text-blue-400 transition-colors">
+                作品集
+              </Link>
+            </div>
+            <div className="md:hidden">
+              <Button size="sm" className="bg-blue-600 hover:bg-blue-700">
+                選單
+              </Button>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      {/* Section 2: 產品主打 */}
+      <section className="bg-gradient-to-br from-slate-900 via-blue-900 to-slate-800 py-24 relative overflow-hidden">
+        <div className="absolute inset-0">
+          <div className="absolute top-20 left-10 w-72 h-72 bg-blue-500/20 rounded-full blur-3xl"></div>
+          <div className="absolute bottom-20 right-10 w-96 h-96 bg-cyan-400/10 rounded-full blur-3xl"></div>
+          <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full h-full">
+            <div className="grid grid-cols-6 gap-8 opacity-5">
+              {Array.from({ length: 24 }).map((_, i) => (
+                <div key={i} className="w-8 h-8 border border-blue-400 rounded"></div>
+              ))}
+            </div>
+          </div>
+        </div>
+        
+        <div className="container mx-auto px-6 relative">
+          <div className="max-w-6xl mx-auto">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+              <div className="space-y-8">
+                <Badge className="bg-blue-500/20 text-blue-300 border-blue-400/30">
+                  🔥 最新科技產品
+                </Badge>
+                
+                <h1 className="text-6xl md:text-7xl font-bold leading-tight">
+                  <span className="text-white block">科技</span>
+                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400">
+                    改變生活
+                  </span>
+                </h1>
+                
+                <p className="text-xl text-gray-300 leading-relaxed max-w-xl">
+                  探索最新的科技產品，從智慧手機到筆記型電腦，我們為您精選高品質的科技商品，讓科技提升您的生活品質。
+                </p>
+                
+                <div className="flex flex-col sm:flex-row gap-4">
+                  <Button size="lg" className="bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 text-white">
+                    立即購買
+                  </Button>
+                  <Button variant="outline" size="lg" className="border-blue-400 text-blue-300 hover:bg-blue-500/10">
+                    瀏覽產品
+                  </Button>
+                </div>
+              </div>
+              
+              <div className="relative">
+                <div className="relative z-10">
+                  <Card className="bg-white/10 backdrop-blur-md border-blue-400/30 shadow-2xl">
+                    <CardHeader>
+                      <div className="h-32 bg-gradient-to-br from-blue-500 to-cyan-500 rounded-lg mb-4 relative overflow-hidden">
+                        <div className="absolute inset-0 bg-white/20 rounded-lg"></div>
+                        <div className="absolute bottom-4 left-4 text-white font-bold text-lg">
+                          Latest Tech
+                        </div>
+                      </div>
+                      <CardTitle className="text-white text-xl">最新科技產品</CardTitle>
+                      <CardDescription className="text-gray-300">頂級品質，創新設計</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-3">
+                        <div className="h-3 bg-white/20 rounded-full w-3/4"></div>
+                        <div className="h-3 bg-white/20 rounded-full w-1/2"></div>
+                        <div className="flex space-x-2 pt-2">
+                          <div className="w-8 h-8 bg-blue-400 rounded-full"></div>
+                          <div className="w-8 h-8 bg-cyan-400 rounded-full"></div>
+                          <div className="w-8 h-8 bg-blue-300 rounded-full"></div>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 3: 產品特色 */}
+      <section className="py-24 bg-gray-50">
+        <div className="container mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl font-bold text-slate-900 mb-6">產品特色</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              我們提供的每一款科技產品都經過嚴格篩選，確保品質與性能都能滿足您的需求
+            </p>
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <Card className="hover:shadow-xl transition-shadow duration-300 border-blue-100">
+              <CardHeader>
+                <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-2xl flex items-center justify-center mb-4">
+                  <div className="w-8 h-8 bg-white rounded-lg"></div>
+                </div>
+                <CardTitle className="text-slate-900">高品質保證</CardTitle>
+                <CardDescription>原廠認證，品質保障</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600">
+                  所有產品都經過原廠認證，提供完整的品質保障和售後服務支援。
+                </p>
+              </CardContent>
+            </Card>
+            
+            <Card className="hover:shadow-xl transition-shadow duration-300 border-blue-100">
+              <CardHeader>
+                <div className="w-16 h-16 bg-gradient-to-br from-cyan-500 to-cyan-600 rounded-2xl flex items-center justify-center mb-4">
+                  <div className="w-8 h-8 bg-white rounded-full"></div>
+                </div>
+                <CardTitle className="text-slate-900">快速配送</CardTitle>
+                <CardDescription>24小時內快速出貨</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600">
+                  高效的物流系統，確保您的訂單能在最短時間內送達您手中。
+                </p>
+              </CardContent>
+            </Card>
+            
+            <Card className="hover:shadow-xl transition-shadow duration-300 border-blue-100">
+              <CardHeader>
+                <div className="w-16 h-16 bg-gradient-to-br from-blue-600 to-purple-600 rounded-2xl flex items-center justify-center mb-4">
+                  <div className="w-8 h-8 bg-white rounded-lg transform rotate-45"></div>
+                </div>
+                <CardTitle className="text-slate-900">專業服務</CardTitle>
+                <CardDescription>專業團隊技術支援</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600">
+                  專業的技術支援團隊，為您解答產品使用上的任何問題。
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 4: 熱門商品 */}
+      <section className="py-24 bg-white">
+        <div className="container mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl font-bold text-slate-900 mb-6">熱門商品</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              精選最受歡迎的科技產品，為您的生活帶來更多便利與樂趣
+            </p>
+          </div>
+          
+          {products.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+              {products.map((product) => (
+                <Card key={product.id} className="group hover:shadow-xl transition-all duration-300 border-blue-100 overflow-hidden">
+                  <div className="relative aspect-square overflow-hidden">
+                    <Image
+                      src={product.image_url}
+                      alt={product.name}
+                      fill
+                      className="object-cover group-hover:scale-105 transition-transform duration-300"
+                    />
+                    <div className="absolute top-4 right-4">
+                      <Badge className="bg-blue-500 text-white">熱門</Badge>
+                    </div>
+                  </div>
+                  <CardHeader>
+                    <CardTitle className="text-slate-900 text-lg group-hover:text-blue-600 transition-colors">
+                      {product.name}
+                    </CardTitle>
+                    <CardDescription className="line-clamp-2">
+                      高品質的科技產品，為您的生活帶來便利
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex items-center justify-between">
+                      <div className="text-2xl font-bold text-blue-600">
+                        {formatPrice(product.price_in_cents)}
+                      </div>
+                      <Button className="bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600">
+                        加入購物車
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-16">
+              <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <div className="w-12 h-12 bg-gray-300 rounded-lg"></div>
+              </div>
+              <h3 className="text-xl font-semibold text-gray-600 mb-2">暫無商品</h3>
+              <p className="text-gray-500">商品資料載入中，請稍後再試</p>
+            </div>
+          )}
+          
+          {products.length > 0 && (
+            <div className="text-center mt-12">
+              <Button variant="outline" size="lg" className="border-blue-500 text-blue-600 hover:bg-blue-50">
+                查看更多商品
+              </Button>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="bg-slate-900 text-white py-16">
+        <div className="container mx-auto px-6">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
+            <div className="col-span-1 md:col-span-2">
+              <div className="text-2xl font-bold text-blue-400 mb-4">TechStore</div>
+              <p className="text-gray-300 leading-relaxed max-w-md">
+                您的科技生活夥伴，提供最新、最優質的科技產品選擇。
+              </p>
+            </div>
+            
+            <div>
+              <h3 className="font-semibold text-white mb-4">商品分類</h3>
+              <ul className="space-y-2 text-gray-300">
+                <li>智慧型手機</li>
+                <li>筆記型電腦</li>
+                <li>平板電腦</li>
+                <li>配件周邊</li>
+              </ul>
+            </div>
+            
+            <div>
+              <h3 className="font-semibold text-white mb-4">快速連結</h3>
+              <ul className="space-y-2 text-gray-300">
+                <li><Link href="/corporate" className="hover:text-blue-400 transition-colors">企業官網</Link></li>
+                <li><Link href="/tech-store" className="hover:text-blue-400 transition-colors">科技商店</Link></li>
+                <li><Link href="/portfolio" className="hover:text-blue-400 transition-colors">作品集</Link></li>
+              </ul>
+            </div>
+          </div>
+          
+          <div className="border-t border-gray-700 pt-8 text-center text-gray-400">
+            <p>&copy; 2025 TechStore. 版權所有。</p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}


### PR DESCRIPTION
根據PRD.md要求實現了3個主要頁面：

- ✅ `/corporate` - 現代企業官網 (7個sections)
- ✅ `/tech-store` - 科技產品商店 (4個sections)
- ✅ `/portfolio` - 設計師作品集 (4個sections)
- ✅ SEO優化（sitemap.xml、robots.txt）
- ✅ 響應式設計與trust-blue色彩方案

技術實現：Next.js 15+、TypeScript、Shadcn/UI、Tailwind CSS

🤖 Generated with [Claude Code](https://claude.ai/code)